### PR TITLE
Optimizations and code cleaning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ To build with a watch that rebuilds on save:
 cargo watch -i .gitignore -i "pkg/*" -s "wasm-pack build --scope novorender --release --features=console"
 ```
 
+At least on linux that line usually makes the npm watch to fail, The following alternative generates the files on a different folder and then copes them to the write location which fixes the problem, a similar command could be used in windows to finally move the files and delete the temporary folder:
+
+```
+cargo watch -i .gitignore -i "pkg/*" -i "pkg_new" -s "wasm-pack build --scope novorender --release --features=console --out-dir pkg_new && mv pkg_new/* pkg/ && rm -rf pkg_new"
+```
+
 To build with debug symbols that can be inspected with chromes WebAssembly DWARF extension;
 
 ```

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,15 +4,42 @@
 mod benches {
     use std::mem::size_of;
 
+    use wasm_parser::thin_slice::ThinSlice;
+
     extern crate test;
     extern crate wasm_parser;
 
     #[bench]
     fn copy(b: &mut test::Bencher) {
-        let src = vec![0f32;1_000_000];
-        let mut dst = vec![0f32;1_000_000];
+        let src0 = vec![0f32; 333_333];
+        let src1 = vec![0f32; 333_333];
+        let src2 = vec![0f32; 333_333];
+        let mut dst = vec![0f32; 999_999];
         b.iter(|| {
-            wasm_parser::interleaved::copy_to_interleaved_array(&mut dst, &src, 0, size_of::<f32>(), 0, src.len());
+            wasm_parser::interleaved::copy_to_interleaved_array(&mut dst, &src0, size_of::<f32>() * 0, size_of::<f32>() * 3, 0, src0.len());
+            wasm_parser::interleaved::copy_to_interleaved_array(&mut dst, &src1, size_of::<f32>() * 1, size_of::<f32>() * 3, 0, src1.len());
+            wasm_parser::interleaved::copy_to_interleaved_array(&mut dst, &src2, size_of::<f32>() * 2, size_of::<f32>() * 3, 0, src2.len());
+        });
+    }
+
+    #[bench]
+    fn copy_three(b: &mut test::Bencher) {
+        let data0 = vec![0f32; 333_333];
+        let data1 = vec![0f32; 333_333];
+        let data2 = vec![0f32; 333_333];
+        let src0 = ThinSlice::from_data_and_offset(bytemuck::cast_slice(&data0), 0, (data0.len() * size_of::<f32>()) as u32);
+        let src1 = ThinSlice::from_data_and_offset(bytemuck::cast_slice(&data1), 0, (data1.len() * size_of::<f32>()) as u32);
+        let src2 = ThinSlice::from_data_and_offset(bytemuck::cast_slice(&data2), 0, (data2.len() * size_of::<f32>()) as u32);
+        let mut dst = vec![0f32; 999_999];
+        b.iter(|| {
+            wasm_parser::interleaved::interleave_three(
+                &mut dst,
+                unsafe{ src0.as_slice(data0.len() as u32) },
+                unsafe{ src1.as_slice(data1.len() as u32) },
+                unsafe{ src2.as_slice(data2.len() as u32) },
+                size_of::<f32>() * 0,
+                size_of::<f32>() * 3,
+            );
         });
     }
 

--- a/src/interleaved.rs
+++ b/src/interleaved.rs
@@ -1,7 +1,5 @@
 use std::mem::size_of;
 
-use crate::thin_slice::{ThinSliceIter, ThinSliceIterator};
-
 pub fn copy_to_interleaved_array<T: Copy + Send + Sync>(dst: &mut [T], src: &[T], byte_offset: usize, byte_stride: usize, begin: usize, end: usize) {
     debug_assert_eq!(byte_offset % size_of::<T>(), 0);
     debug_assert_eq!(byte_stride % size_of::<T>(), 0);
@@ -23,62 +21,120 @@ pub fn fill_to_interleaved_array<T: Copy + Send + Sync>(dst: &mut [T], src: T, b
 
     let end = (offset + stride * (end - begin)).min(dst.len());
 
-    for dst in dst[offset..end].iter_mut().step_by(stride) {
-        *dst = src;
+    if stride == 1 {
+        dst[offset..end].fill(src);
+    }else{
+        for dst in dst[offset..end].iter_mut().step_by(stride) {
+            *dst = src;
+        }
     }
 }
 
-pub fn interleave_one<T: Copy + 'static>(dst: &mut[T], mut src0: ThinSliceIter<T>, byte_offset: usize, byte_stride: usize, len: usize) {
+pub fn interleave_one<T: Copy + 'static>(dst: &mut[T], src: &[T], byte_offset: usize, byte_stride: usize) {
     debug_assert_eq!(byte_offset % size_of::<T>(), 0);
     debug_assert_eq!(byte_stride % size_of::<T>(), 0);
 
     let offset = byte_offset / size_of::<T>();
     let stride = byte_stride / size_of::<T>();
 
-    for dst in dst[offset..].iter_mut().step_by(stride).take(len) {
-        *dst = unsafe{ *src0.next() };
+    for (dst, src) in dst[offset..].iter_mut().step_by(stride).zip(src) {
+        *dst = *src;
     }
 }
 
-pub fn interleave_two<T: Copy + 'static>(dst: &mut[T], mut src0: ThinSliceIter<T>, mut src1: ThinSliceIter<T>, byte_offset: usize, byte_stride: usize, len: usize) {
+pub fn interleave_two<T: Copy + bytemuck::Pod + 'static>(dst: &mut[T], src0: &[T], src1: &[T], byte_offset: usize, byte_stride: usize) {
     debug_assert_eq!(byte_offset % size_of::<T>(), 0);
     debug_assert_eq!(byte_stride % size_of::<T>(), 0);
 
     let offset = byte_offset / size_of::<T>();
     let stride = byte_stride / size_of::<T>();
 
-    for dst in dst[offset..].chunks_mut(stride).take(len) {
-        dst[0] = unsafe{ *src0.next() };
-        dst[1] = unsafe{ *src1.next() };
+    if stride == 2 {
+        for ((dst, src0), src1) in bytemuck::cast_slice_mut::<T, [T;2]>(&mut dst[offset..])
+            .iter_mut()
+            .zip(src0)
+            .zip(src1)
+        {
+            dst[0] = *src0;
+            dst[1] = *src1;
+        }
+    }else{
+        for ((dst, src0), src1) in dst[offset..]
+            .chunks_mut(stride)
+            .zip(src0)
+            .zip(src1)
+        {
+            dst[0] = *src0;
+            dst[1] = *src1;
+        }
     }
 }
 
-pub fn interleave_three<T: Copy + 'static>(dst: &mut[T], mut src0: ThinSliceIter<T>, mut src1: ThinSliceIter<T>, mut src2: ThinSliceIter<T>, byte_offset: usize, byte_stride: usize, len: usize) {
+pub fn interleave_three<T: Copy + bytemuck::Pod + 'static>(dst: &mut[T], src0: &[T], src1: &[T], src2: &[T], byte_offset: usize, byte_stride: usize) {
     debug_assert_eq!(byte_offset % size_of::<T>(), 0);
     debug_assert_eq!(byte_stride % size_of::<T>(), 0);
 
     let offset = byte_offset / size_of::<T>();
     let stride = byte_stride / size_of::<T>();
 
-    for dst in dst[offset..].chunks_mut(stride).take(len) {
-        dst[0] = unsafe{ *src0.next() };
-        dst[1] = unsafe{ *src1.next() };
-        dst[2] = unsafe{ *src2.next() };
+    if stride == 3 {
+        for (((dst, src0), src1), src2) in bytemuck::cast_slice_mut::<T, [T;3]>(&mut dst[offset..])
+            .iter_mut()
+            .zip(src0)
+            .zip(src1)
+            .zip(src2)
+        {
+            dst[0] = *src0;
+            dst[1] = *src1;
+            dst[2] = *src2;
+        }
+    }else{
+        for (((dst, src0), src1), src2) in dst[offset..]
+            .chunks_mut(stride)
+            .zip(src0)
+            .zip(src1)
+            .zip(src2)
+        {
+            dst[0] = *src0;
+            dst[1] = *src1;
+            dst[2] = *src2;
+        }
     }
 }
 
-pub fn interleave_four<T: Copy + 'static>(dst: &mut[T], mut src0: ThinSliceIter<T>, mut src1: ThinSliceIter<T>, mut src2: ThinSliceIter<T>, mut src3: ThinSliceIter<T>, byte_offset: usize, byte_stride: usize, len: usize) {
+pub fn interleave_four<T: Copy + bytemuck::Pod + 'static>(dst: &mut[T], src0: &[T], src1: &[T], src2: &[T], src3: &[T], byte_offset: usize, byte_stride: usize) {
     debug_assert_eq!(byte_offset % size_of::<T>(), 0);
     debug_assert_eq!(byte_stride % size_of::<T>(), 0);
 
     let offset = byte_offset / size_of::<T>();
     let stride = byte_stride / size_of::<T>();
 
-    for dst in dst[offset..].chunks_mut(stride).take(len) {
-        dst[0] = unsafe{ *src0.next() };
-        dst[1] = unsafe{ *src1.next() };
-        dst[2] = unsafe{ *src2.next() };
-        dst[3] = unsafe{ *src3.next() };
+    if stride == 4 {
+        for ((((dst, src0), src1), src2), src3) in bytemuck::cast_slice_mut::<T, [T;4]>(&mut dst[offset..])
+            .iter_mut()
+            .zip(src0)
+            .zip(src1)
+            .zip(src2)
+            .zip(src3)
+        {
+            dst[0] = *src0;
+            dst[1] = *src1;
+            dst[2] = *src2;
+            dst[3] = *src3;
+        }
+    }else{
+        for ((((dst, src0), src1), src2), src3) in dst[offset..]
+            .chunks_mut(stride)
+            .zip(src0)
+            .zip(src1)
+            .zip(src2)
+            .zip(src3)
+        {
+            dst[0] = *src0;
+            dst[1] = *src1;
+            dst[2] = *src2;
+            dst[3] = *src3;
+        }
     }
 }
 
@@ -92,6 +148,16 @@ mod test {
         let mut dst = [0.; 14];
         super::copy_to_interleaved_array(&mut dst, &src, size_of::<f32>() * 2, size_of::<f32>() * 2, 1, 7);
         assert_eq!(dst, [0., 0., 1., 0., 2., 0., 3., 0., 4., 0., 5., 0., 6., 0.]);
+    }
+
+    #[test]
+    fn test_copy_interleaved_three() {
+        let src0 = [0f32;7];
+        let src1 = [0f32;7];
+        let src2 = [0f32, 1., 2., 3., 4., 5., 6.];
+        let mut dst = [0.; 21];
+        super::interleave_three(&mut dst, &src0, &src1, &src2, 0, size_of::<f32>() * 3);
+        assert_eq!(dst, [0., 0., 0., 0., 0., 1., 0., 0., 2., 0., 0., 3., 0., 0., 4., 0., 0., 5., 0., 0., 6.]);
     }
 
     #[test]

--- a/src/interleaved.rs
+++ b/src/interleaved.rs
@@ -37,8 +37,12 @@ pub fn interleave_one<T: Copy + 'static>(dst: &mut[T], src: &[T], byte_offset: u
     let offset = byte_offset / size_of::<T>();
     let stride = byte_stride / size_of::<T>();
 
-    for (dst, src) in dst[offset..].iter_mut().step_by(stride).zip(src) {
-        *dst = *src;
+    if stride == 1 {
+        dst[offset..offset + src.len()].copy_from_slice(src)
+    }else{
+        for (dst, src) in dst[offset..].iter_mut().step_by(stride).zip(src) {
+            *dst = *src;
+        }
     }
 }
 

--- a/src/interleaved.rs
+++ b/src/interleaved.rs
@@ -1,5 +1,7 @@
 use std::mem::size_of;
 
+use crate::thin_slice::{ThinSliceIter, ThinSliceIterator};
+
 pub fn copy_to_interleaved_array<T: Copy + Send + Sync>(dst: &mut [T], src: &[T], byte_offset: usize, byte_stride: usize, begin: usize, end: usize) {
     debug_assert_eq!(byte_offset % size_of::<T>(), 0);
     debug_assert_eq!(byte_stride % size_of::<T>(), 0);
@@ -12,7 +14,6 @@ pub fn copy_to_interleaved_array<T: Copy + Send + Sync>(dst: &mut [T], src: &[T]
     }
 }
 
-
 pub fn fill_to_interleaved_array<T: Copy + Send + Sync>(dst: &mut [T], src: T, byte_offset: usize, byte_stride: usize, begin: usize, end: usize) {
     debug_assert_eq!(byte_offset % size_of::<T>(), 0);
     debug_assert_eq!(byte_stride % size_of::<T>(), 0);
@@ -24,6 +25,60 @@ pub fn fill_to_interleaved_array<T: Copy + Send + Sync>(dst: &mut [T], src: T, b
 
     for dst in dst[offset..end].iter_mut().step_by(stride) {
         *dst = src;
+    }
+}
+
+pub fn interleave_one<T: Copy + 'static>(dst: &mut[T], mut src0: ThinSliceIter<T>, byte_offset: usize, byte_stride: usize, len: usize) {
+    debug_assert_eq!(byte_offset % size_of::<T>(), 0);
+    debug_assert_eq!(byte_stride % size_of::<T>(), 0);
+
+    let offset = byte_offset / size_of::<T>();
+    let stride = byte_stride / size_of::<T>();
+
+    for dst in dst[offset..].iter_mut().step_by(stride).take(len) {
+        *dst = unsafe{ *src0.next() };
+    }
+}
+
+pub fn interleave_two<T: Copy + 'static>(dst: &mut[T], mut src0: ThinSliceIter<T>, mut src1: ThinSliceIter<T>, byte_offset: usize, byte_stride: usize, len: usize) {
+    debug_assert_eq!(byte_offset % size_of::<T>(), 0);
+    debug_assert_eq!(byte_stride % size_of::<T>(), 0);
+
+    let offset = byte_offset / size_of::<T>();
+    let stride = byte_stride / size_of::<T>();
+
+    for dst in dst[offset..].chunks_mut(stride).take(len) {
+        dst[0] = unsafe{ *src0.next() };
+        dst[1] = unsafe{ *src1.next() };
+    }
+}
+
+pub fn interleave_three<T: Copy + 'static>(dst: &mut[T], mut src0: ThinSliceIter<T>, mut src1: ThinSliceIter<T>, mut src2: ThinSliceIter<T>, byte_offset: usize, byte_stride: usize, len: usize) {
+    debug_assert_eq!(byte_offset % size_of::<T>(), 0);
+    debug_assert_eq!(byte_stride % size_of::<T>(), 0);
+
+    let offset = byte_offset / size_of::<T>();
+    let stride = byte_stride / size_of::<T>();
+
+    for dst in dst[offset..].chunks_mut(stride).take(len) {
+        dst[0] = unsafe{ *src0.next() };
+        dst[1] = unsafe{ *src1.next() };
+        dst[2] = unsafe{ *src2.next() };
+    }
+}
+
+pub fn interleave_four<T: Copy + 'static>(dst: &mut[T], mut src0: ThinSliceIter<T>, mut src1: ThinSliceIter<T>, mut src2: ThinSliceIter<T>, mut src3: ThinSliceIter<T>, byte_offset: usize, byte_stride: usize, len: usize) {
+    debug_assert_eq!(byte_offset % size_of::<T>(), 0);
+    debug_assert_eq!(byte_stride % size_of::<T>(), 0);
+
+    let offset = byte_offset / size_of::<T>();
+    let stride = byte_stride / size_of::<T>();
+
+    for dst in dst[offset..].chunks_mut(stride).take(len) {
+        dst[0] = unsafe{ *src0.next() };
+        dst[1] = unsafe{ *src1.next() };
+        dst[2] = unsafe{ *src2.next() };
+        dst[3] = unsafe{ *src3.next() };
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -817,7 +817,9 @@ macro_rules! impl_parser {
                     primitive_type: PrimitiveType,
                     attributes: OptionalVertexAttribute,
                     num_deviations: u8,
-                    group_meshes: Vec<SubMesh<'a>>
+                    group_meshes: Vec<SubMesh<'a>>,
+                    has_materials: bool,
+                    has_object_ids: bool,
                 }
 
                 #[derive(Hash, PartialEq, Eq)]
@@ -837,6 +839,8 @@ macro_rules! impl_parser {
                         attributes,
                         num_deviations,
                         child_index,
+                        material_index,
+                        object_id,
                         ..
                     } = sub_mesh;
 
@@ -851,8 +855,12 @@ macro_rules! impl_parser {
                         primitive_type,
                         attributes,
                         num_deviations: num_deviations,
+                        has_materials: false,
+                        has_object_ids: false,
                         group_meshes: vec![]
                     });
+                    group.has_materials |= material_index != u8::MAX;
+                    group.has_object_ids |= object_id != u32::MAX;
                     group.group_meshes.push(sub_mesh);
                 }
 
@@ -861,21 +869,21 @@ macro_rules! impl_parser {
                     primitive_type,
                     attributes,
                     num_deviations,
-                    group_meshes
+                    group_meshes,
+                    has_materials,
+                    has_object_ids,
                 } in groups.values() {
                     if group_meshes.is_empty() {
                         continue
                     }
 
-                    let has_materials = group_meshes.iter().any(|m| m.material_index != u8::MAX);
-                    let has_object_ids = group_meshes.iter().any(|m| m.object_id != u32::MAX);
                     let position_stride = compute_vertex_position_deviations_offsets(*num_deviations).stride as usize;
                     let triangle_pos_stride = position_stride * 3;
                     let attrib_offsets = compute_vertex_attributes_offsets(
                         *attributes,
                         *num_deviations,
-                        has_materials,
-                        has_object_ids
+                        *has_materials,
+                        *has_object_ids
                     );
                     let vertex_stride = attrib_offsets.stride as usize;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -356,11 +356,10 @@ pub enum Indices {
     NumIndices(u32),
 }
 
-
+// substitute with macro_rules! ... to get proper autcomplete on the implementation
 // use crate::types_2_0::*;
 // use crate::reader_2_0::*;
 // use _2_0::*;
-// use crate::parser::*;
 
 macro_rules! impl_parser {
     ($version: ident, $child_ty: ty $(, $child_extra_fields: ident)*) => { paste::paste! {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1013,8 +1013,8 @@ macro_rules! impl_parser {
                     let mut index_offset = 0;
                     let mut vertex_offset = 0;
                     let mut triangle_offset = 0;
-                    let mut object_ranges = vec![];
-                    let mut draw_ranges = vec![];
+                    let mut object_ranges = Vec::with_capacity(group_meshes.len());
+                    let mut draw_ranges = Vec::with_capacity(group_meshes.len());
 
                     let draw_range_begin = if index_buffer.is_some() {
                         index_offset

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -917,8 +917,8 @@ macro_rules! impl_parser {
                         material_type,
                         primitive_type,
                         attributes,
-                        num_deviations: num_deviations,
-                        child_index: child_index,
+                        num_deviations,
+                        child_index,
                     }).or_insert_with(|| Group {
                         material_type,
                         primitive_type,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -809,7 +809,7 @@ macro_rules! impl_parser {
             }
 
             pub fn geometry(&self, enable_outlines: bool, highlights: &Highlights, filter: impl Fn(u32) -> bool) -> (Vec<ReturnSubMesh>, Vec<Option<Texture>>){
-                let mut sub_meshes = vec![];
+                let mut sub_meshes = Vec::with_capacity(self.sub_mesh.len as usize);
                 let mut referenced_textures = HashMap::new();
 
                 struct Group<'a> {
@@ -857,7 +857,7 @@ macro_rules! impl_parser {
                         num_deviations,
                         has_materials: false,
                         has_object_ids: false,
-                        group_meshes: vec![]
+                        group_meshes: Vec::with_capacity(self.sub_mesh.len as usize)
                     });
                     group.has_materials |= material_index != u8::MAX;
                     group.has_object_ids |= object_id != u32::MAX;
@@ -1126,7 +1126,7 @@ macro_rules! impl_parser {
                     });
 
                     fn enumerate_buffers(possible_buffers: PossibleBuffers) -> (Vec<Vec<u8>>, BufIndex) {
-                        let mut buffers = vec![];
+                        let mut buffers = Vec::with_capacity(6);
                         let index = BufIndex {
                             primary: {
                                 let id = buffers.len();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1242,7 +1242,7 @@ macro_rules! impl_parser {
                         highlight_tri: VertexAttribute { kind: "UNSIGNED_INT", buffer: buf_index.highlight_tri, component_count: 1, component_type: "UNSIGNED_BYTE", normalized: false, byte_offset: 0, byte_stride: 0 },
                     };
 
-                    object_ranges.sort_by_key(|obj_range| obj_range.object_id);
+                    object_ranges.sort_unstable_by_key(|obj_range| obj_range.object_id);
 
                     sub_meshes.push(ReturnSubMesh{
                         material_type: *material_type,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -854,7 +854,7 @@ macro_rules! impl_parser {
                         material_type,
                         primitive_type,
                         attributes,
-                        num_deviations: num_deviations,
+                        num_deviations,
                         has_materials: false,
                         has_object_ids: false,
                         group_meshes: vec![]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -882,10 +882,6 @@ macro_rules! impl_parser {
             }
 
             pub fn geometry(&self, enable_outlines: bool, highlights: &Highlights, filter: impl Fn(u32) -> bool) -> (Vec<ReturnSubMesh>, Vec<Option<Texture>>){
-                // TODO: This is only to check if there's a global indices buffer but maybe just
-                // check sub_mesh.indices.is_empty()
-                let vertex_index = &self.vertex_index;
-
                 let mut sub_meshes = vec![];
                 let mut referenced_textures = HashMap::new();
 
@@ -996,7 +992,7 @@ macro_rules! impl_parser {
 
                     let index_buffer_bytes_per_element;
                     let mut index_buffer;
-                     if vertex_index.is_some() {
+                     if num_indices != 0 {
                         let bytes_per_element = if num_vertices < u16::MAX as usize {
                             size_of::<u16>()
                         }else{
@@ -1079,7 +1075,7 @@ macro_rules! impl_parser {
                             if let (Some(triangle_pos_buffer), Some(triangle_object_id_buffer))
                                 = (&mut triangle_pos_buffer, &mut triangle_object_id_buffer)
                             {
-                                if vertex_index.is_some() && index_buffer.is_some() {
+                                if index_buffer.is_some() {
                                     num_triangles_in_submesh = sub_mesh.indices.len() / 3;
                                     let (x, y ,z) = (
                                         sub_mesh.vertices.position.x,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -37,7 +37,7 @@ fn test_parser() -> anyhow::Result<()>{
 
     // TODO: test something about the children
 
-    let (sub_meshes, textures) = schema.geometry(
+    let (_sub_meshes, _textures)  = schema.geometry(
         false,
         &Highlights::default(),
         |_| true


### PR DESCRIPTION
- Interleave all components at once rather than one after another
- Fast paths for interleaving exact stride
- Reserve capacity for all vectors in geometry
- All buffers are u8 and cast to be filled (avoids some copies)
- Remove extra unnecessary nested loop for child indices
- Missing sort -> sort_unstable